### PR TITLE
Various fixes for Mac OS X CMake configuration.

### DIFF
--- a/cmake/macosx.cmake
+++ b/cmake/macosx.cmake
@@ -1,7 +1,9 @@
 # Default CMake Setup. Used for Mac OS x builds
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+message( STATUS "Architecture: ${ARCHITECTURE}" )
 
 # For INTeL 32bit Mac OS X 10.5+
-set(CMAKE_CXX_FLAGS " -O2 -force_cpusubtype_ALL -arch i386 -m32 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk -mmacosx-version-min=10.7")
+set(CMAKE_CXX_FLAGS " -O2 -force_cpusubtype_ALL -arch ${ARCHITECTURE} -m32 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -mmacosx-version-min=10.7")
 
 # # For PowerPC 32bit Mac OS X 10.5+
 # set(CMAKE_CXX_FLAGS " -std=c++11 -stdlib=libstdc++ -O2 -faltivec -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch ppc -m32 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk -mmacosx-version-min=10.7")
@@ -9,22 +11,21 @@ set(CMAKE_CXX_FLAGS " -O2 -force_cpusubtype_ALL -arch i386 -m32 -isysroot /Appli
 # Use OpenGL for rendering
 set(OPENGL 1)
 
-# This is for Homebrew
-set(lib_base /usr/local/Cellar)
-set(sdl_root ${lib_base}/sdl/1.2.15)
+find_package(SDL REQUIRED)
+find_package(Boost REQUIRED)
 
-include_directories("${sdl_root}/include/SDL/" "${lib_base}/include/" "~/Library/Frameworks/SDL.framework/Headers" "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/usr/X11/include/" "${lib_base}/boost/1.60.0_1/include")
+include_directories(${SDL_INCLUDE_DIR} "${lib_base}/include/" "~/Library/Frameworks/SDL.framework/Headers" "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/X11/include/" ${Boost_INCLUDE_DIRS})
 
 find_library(COCOA_LIBRARY Cocoa)
 find_library(GLUT_LIBRARY GLUT )
 find_library(OpenGL_LIBRARY OpenGL )
 
 link_libraries(cannonball 
-    SDL
-    SDLmain
+    ${SDL_LIBRARY}
     ${COCOA_LIBRARY}
     ${GLUT_LIBRARY}
     ${OpenGL_LIBRARY}
+    ${Boost_LIBRARIES}
 )
 
 # Linking


### PR DESCRIPTION
 - Use "uname -m" to determine architecture
 - Use "MacOSX.sdk" instead of versioned filename (this is symlinked to
   the current version)
 - Use CMake find_package for SDL and Boost dependencies