### PR TITLE
RPI: use new vendor graphics library name

### DIFF
--- a/cmake/sdl2gles_rpi.cmake
+++ b/cmake/sdl2gles_rpi.cmake
@@ -9,7 +9,7 @@ include_directories("${sdl_root}")
 
 link_libraries(cannonball 
     SDL2
-    GLESv2
+    brcmGLESv2
 )
 
 # Linking


### PR DESCRIPTION
Needed to build on Raspbian stretch due to the old vendor library names being obsoleted.