### PR TITLE
Updated the GLES shaders and rpi-specific cmake files

### DIFF
--- a/cmake/sdl2_rpi.cmake
+++ b/cmake/sdl2_rpi.cmake
@@ -14,7 +14,7 @@ link_directories(
     "${sdl_root}/lib"
 )
 
-add_definitions(-O3 -DSDL2 -march=armv6 -mfpu=vfp -mfloat-abi=hard)
+add_definitions(-O3 -DSDL2 -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard)
  
 # Location for Cannonball to create save files
 # Used to auto-generate setup.hpp with various file paths

--- a/cmake/sdl2gles_rpi.cmake
+++ b/cmake/sdl2gles_rpi.cmake
@@ -17,7 +17,7 @@ link_directories(
     "${sdl_root}/lib"
 )
 
-add_definitions(-O3 -DSDL2 -DWITH_OPENGLES -march=armv6 -mfpu=vfp -mfloat-abi=hard)
+add_definitions(-O3 -DSDL2 -DWITH_OPENGLES -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard)
 #add_definitions(-O0 -ggdb -DSDL2 -DWITH_OPENGLES)
  
 # Location for Cannonball to create save files

--- a/src/main/sdl2/rendergles.hpp
+++ b/src/main/sdl2/rendergles.hpp
@@ -29,6 +29,7 @@ struct __ShaderInfo
    GLint input_size;
    GLint output_size;
    GLint texture_size;
+   GLfloat scanline_bright;
 };
 
 class RenderGLES : public RenderBase


### PR DESCRIPTION
I improved the GLES scanlines shader so it does not show patterns on different screen resolutions.
Also, changed gcc default flags to Rpi3, since having them as Rpi1 defaults had no sense (Cannonball is not fullspeed on a Pi1, and the Pi2 is using the same SOC as the Pi2 nowadays).