### PR TITLE
Unbreak with Clang/LLD 9

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -10,11 +10,13 @@
 
 // SDL Library
 #include <SDL.h>
+#ifdef _WIN32
 #ifndef SDL2
 #pragma comment(lib, "SDLmain.lib") // Replace main with SDL_main
 #endif
 #pragma comment(lib, "SDL.lib")
 #pragma comment(lib, "glu32.lib")
+#endif
 
 // SDL Specific Code
 #if defined SDL2


### PR DESCRIPTION
Regressed by https://github.com/llvm/llvm-project/commit/1d16515fb407. Found via [freebsd#240629](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240629).
```
$ c++ --version
FreeBSD clang version 9.0.0 (tags/RELEASE_900/final 372316) (based on LLVM 9.0.0)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin
$ c++ -Wl,--version
LLD 9.0.0 (FreeBSD 372316-1300004) (compatible with GNU linkers)

$ git describe --tags --always
v0.3-26-g48d2c62

$ cd cmake
$ cmake -GNinja -DTARGET=bsd -DBSD_PREFIX_PATH=/usr/local .
$ ninja
[...]
ld: error: CMakeFiles/cannonball.dir/tmp/cannonball/src/main/main.cpp.o: unable to find library from dependent library specifier: SDLmain.lib
ld: error: CMakeFiles/cannonball.dir/tmp/cannonball/src/main/main.cpp.o: unable to find library from dependent library specifier: SDL.lib
ld: error: CMakeFiles/cannonball.dir/tmp/cannonball/src/main/main.cpp.o: unable to find library from dependent library specifier: glu32.lib
c++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
http://package18.nyi.freebsd.org/data/headamd64PR240629-default/2019-09-21_22h04m49s/logs/errors/cannonball-g20190819.log
