### PR TITLE
Support SDL2 by default in FreeBSD / NetBSD.

### DIFF
--- a/cmake/bsd.cmake
+++ b/cmake/bsd.cmake
@@ -4,13 +4,31 @@ set(lib_base ${BSD_PREFIX_PATH}/include)
 
 set(BOOST_INCLUDEDIR ${lib_base})
 
-set(sdl_root ${lib_base}/SDL)
+# Use legacy SDL1.x if requested
+if(SDL)
+        set(sdl_root ${lib_base}/SDL)
+
+        link_libraries(cannonball
+            SDL
+        )
+
+        set(sdl_flags "SDL_DOUBLEBUF | SDL_SWSURFACE")
+else()  # Use SDL2 by default
+        set(sdl_root ${lib_base}/SDL2)
+
+        link_libraries(cannonball
+            SDL2
+        )
+
+        add_definitions(-O3 -DSDL2)
+
+        set(sdl_flags "SDL_WINDOW_RESIZABLE")
+
+        # Set SDL2 instead of SDL1
+        set(SDL2 1)
+endif()
 
 include_directories("${sdl_root}")
-
-link_libraries(cannonball
-    SDL
-)
 
 # Linking
 link_directories(
@@ -20,4 +38,3 @@ link_directories(
 # Location for Cannonball to create save files
 # Used to auto-generate setup.hpp with various file paths
 set(xml_directory ./)
-set(sdl_flags "SDL_DOUBLEBUF | SDL_SWSURFACE")


### PR DESCRIPTION
Modified `bsd.cmake` to support SDL2 by default.

I tested out the builds in NetBSD and FreeBSD and it seems to work correctly.
 
SDL1.x option is still available and only used for build if passed in with the flag `-DSDL=1`

Let me know if this looks for a merge.