### PR TITLE
Add linux target

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Everything should go into a win64.cmake equivalent.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.18) # Might compile lower, but untested
+cmake_minimum_required (VERSION 3.16) # Might compile lower, but untested
 project (cannonball)
 
 # -----------------------------------------------------------------------------

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -1,0 +1,11 @@
+# -----------------------------------------------------------------------------
+# CannonBall Linux Setup
+# -----------------------------------------------------------------------------
+
+# Use OpenGL for rendering.
+find_package(OpenGL REQUIRED)
+
+# Platform Specific Libraries
+set(platform_link_libs
+    ${OPENGL_LIBRARIES}
+)


### PR DESCRIPTION
Simple cmake file for linux build. Use with -DTARGET=linux
I'm not a cmake expert so there might be room for improvement but works for me.
Also lowered the cmake requirement to 3.16 which is the one I have installed.