### PR TITLE
Implement modern SDL2 controller handling

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -85,6 +85,26 @@ static void process_events(void)
                 input.handle_key_up(&event.key.keysym);
                 break;
 
+            case SDL_CONTROLLERAXISMOTION:
+                input.handle_controller_axis(&event.caxis);
+                break;
+
+            case SDL_CONTROLLERBUTTONDOWN:
+                input.handle_controller_down(&event.cbutton);
+                break;
+
+            case SDL_CONTROLLERBUTTONUP:
+                input.handle_controller_up(&event.cbutton);
+                break;
+
+            case SDL_CONTROLLERDEVICEADDED:
+                input.open_joy();
+                break;
+
+            case SDL_CONTROLLERDEVICEREMOVED:
+                input.close_joy();
+                break;
+
             case SDL_JOYAXISMOTION:
                 input.handle_joy_axis(&event.jaxis);
                 break;
@@ -287,7 +307,7 @@ int main(int argc, char* argv[])
         std::cout << "Unable to load controller mapping" << std::endl;
 
     // Initialize timer and video systems
-    if (SDL_Init(SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) == -1)
+    if (SDL_Init(SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) == -1)
     {
         std::cerr << "SDL Initialization Failed: " << SDL_GetError() << std::endl;
         return 1;

--- a/src/main/sdl2/input.hpp
+++ b/src/main/sdl2/input.hpp
@@ -65,6 +65,9 @@ public:
 
     void handle_key_up(SDL_Keysym*);
     void handle_key_down(SDL_Keysym*);
+    void handle_controller_axis(SDL_ControllerAxisEvent*);
+    void handle_controller_down(SDL_ControllerButtonEvent*);
+    void handle_controller_up(SDL_ControllerButtonEvent*);
     void handle_joy_axis(SDL_JoyAxisEvent*);
     void handle_joy_down(SDL_JoyButtonEvent*);
     void handle_joy_up(SDL_JoyButtonEvent*);
@@ -81,6 +84,7 @@ private:
 
     // SDL Joystick / Keypad
     SDL_Joystick *stick;
+    SDL_GameController* controller;
 
     // Configurations for keyboard and joypad
     int pad_id;
@@ -98,6 +102,7 @@ private:
     void bind_button(SDL_GameController* controller, SDL_GameControllerButton button, int offset);
     void handle_key(const int, const bool);
     void handle_joy(const uint8_t, const bool);
+    void handle_axis(const uint8_t, const int16_t);
     void store_last_axis(const uint8_t axis, const int16_t value);
 };
 


### PR DESCRIPTION
This will make use of the game controller interface over the joystick interface for input handling, this allows for a consistent button index between controllers to be saved in the config.xml file, it also allows for different controllers to make use of the same mapping.

It isn't compatible with previous mappings though, so I don't know if you want to add another config section for controller mappings specifically or not.

This takes care of #77 