### PR TITLE
Fix vsync control in both GLES and OpenGL renderers.

### DIFF
--- a/src/main/sdl2/rendergl.cpp
+++ b/src/main/sdl2/rendergl.cpp
@@ -114,9 +114,6 @@ bool Render::init(int src_width, int src_height,
 
     glcontext = SDL_GL_CreateContext(window);
 
-    // Attempt to use V-Sync if enabled
-    SDL_GL_SetSwapInterval(config.video.vsync);
-
     if (!surface)
     {
         std::cerr << "Video mode set failed: " << SDL_GetError() << std::endl;
@@ -291,5 +288,5 @@ void Render::draw_frame(uint16_t* pixels)
 
 bool Render::supports_vsync()
 {
-    return SDL_GL_GetSwapInterval() == 1;
+    return SDL_GL_SetSwapInterval(1) == 0;
 }

--- a/src/main/sdl2/rendergles.cpp
+++ b/src/main/sdl2/rendergles.cpp
@@ -504,6 +504,6 @@ void Render::draw_frame(uint16_t* pixels)
 
 bool Render::supports_vsync()
 {
-	return SDL_GL_GetSwapInterval() == 1;
+    return SDL_GL_SetSwapInterval(1) == 0;
 }
 


### PR DESCRIPTION
Using` SDL_GL_GetSwapInterval()` to find out if VSYNC is supported or not makes no sense:  `SDL_GL_GetSwapInterval()` returns the current VSYNC setting, so if VSYNC is not set previously via `SDL_GL_SetSwapInterval(1)`, then  `SDL_GL_GetSwapInterval()` will ALWAYS return false.

So, simply using `SDL_GL_SetSwapInterval(1)` on both OpenGL and GLES `Render::supports_vsync` methods tries to activate VSYNC, and so the method returns `true` if VSYNC activation was successful.

This fix is much needed, as video is broken on any OpenGL/GLES platform without it. 