### PR TITLE
Make it easier to enter initials with keyboard controls on the high-score page

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,7 +13,35 @@ project (cannonball)
 # -----------------------------------------------------------------------------
 
 # CMake default file (override with -DTARGET=file)
-set(DCMAKE win64-opengl.cmake)
+if(NOT DEFINED TARGET)
+	# Check to see whether the toolchain is set up for a particular CPU target
+	if (DEFINED CMAKE_CXX_FLAGS AND CMAKE_CXX_FLAGS MATCHES ".*-march=.*")
+        set(TARGET_ARCH_REGEX "^.*-march[= ]([^ ]+).*$")
+        string(REGEX MATCH "${TARGET_ARCH_REGEX}" TARGET_ARCH_MATCH ${CMAKE_CXX_FLAGS})
+        if (TARGET_ARCH_MATCH)
+           string(REGEX REPLACE "${TARGET_ARCH_REGEX}" "\\1" TARGET_ARCH ${CMAKE_CXX_FLAGS})
+        else()
+			# Could not extract target architecture, assume same as host
+            set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+		endif()
+	else()
+		# Assume we are not cross-compiling
+        set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    endif()
+	message("Detected target architecture as ${TARGET_ARCH}")
+
+	if (TARGET_ARCH MATCHES "[Aa]?[Aa][Rr][Mm].*")
+		message("Detected ARM target, setting up for Rasberry Pi OpenGL ES build; use -DTARGET= to change")
+        set(DCMAKE pi4-opengles.cmake)
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+		message("Automatically setting up for a Windows build; use -DTARGET= to change")
+        set(DCMAKE win64-opengl.cmake)
+    else()
+		message("Automatically setting up for a Linux/Unix build; use -DTARGET= to change")
+		set(OpenGL_GL_PREFERENCE GLVND)
+        set(DCMAKE linux.cmake)
+    endif()
+endif()
 
 # Source location
 set(main_cpp_base ../src/main)

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -386,6 +386,17 @@ void OHiScore::do_input(uint32_t adr)
 // Source: 0xD4DA
 int8_t OHiScore::read_controls()
 {
+    int fast_threshold, slow_threshold;
+
+    if (input.analog || input.gamepad) {
+        fast_threshold = 0x30;
+        slow_threshold = 0x10;
+    } else {
+	// Don't demand as much of a steering input to change letters when using keyboard
+        fast_threshold = 0x10;
+        slow_threshold = 0x04;
+    }
+
     // Determine when accelerator has been pressed then depressed
     if (oinputs.input_acc < 0x30)
     {
@@ -404,7 +415,7 @@ int8_t OHiScore::read_controls()
 
     // Check Steering Wheel
     int8_t movement = 1; // default to right
-    int16_t steering = (oinputs.input_steering & 0xFF) - 0x80;
+    int16_t steering = (oinputs.input_steering & 0xFF) - OInputs::STEERING_CENTRE;
     if (steering < 0)
     {
         steering = -steering;
@@ -413,9 +424,9 @@ int8_t OHiScore::read_controls()
 
     // Set increment to potentially advance to next letter.
     // This depends on how far the steering wheel is turned.
-    if (steering >= 0x30)
+    if (steering >= fast_threshold)
         steer += 5;
-    else if (steering >= 0x10)
+    else if (steering >= slow_threshold)
         steer += 1;
 
     if (steer >= 0x14)

--- a/src/main/engine/oinputs.hpp
+++ b/src/main/engine/oinputs.hpp
@@ -51,6 +51,9 @@ public:
     bool is_analog_r();
     bool is_analog_select();
 
+    // Steering position is a one-byte value, center of range == neutral
+    const static uint8_t STEERING_CENTRE = 0x80;
+
 private:
     // ------------------------------------------------------------------------
     // Variables for port
@@ -77,7 +80,6 @@ private:
 
     const static uint8_t STEERING_MIN = 0x48;
     const static uint8_t STEERING_MAX = 0xB8;
-    const static uint8_t STEERING_CENTRE = 0x80;
     
     // Current steering value
     int16_t steering_old;

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -23,6 +23,9 @@ public:
     void populate();
     void init(bool init_main_menu = true);
     void tick();
+    void set_next_menu(int which);
+
+    enum { MAIN_MENU, CONFIRM_QUIT };
 
 private:
     CabDiag* cabdiag;
@@ -94,15 +97,18 @@ private:
     std::vector<std::string> menu_s_tests;          // smartypi specific
     std::vector<std::string> menu_s_dips;           // smartypi specific
     std::vector<std::string> menu_s_enhance;        // smartypi specific
+    std::vector<std::string> menu_confirm_quit;
 
     std::vector<std::string> text_redefine;
     
     void populate_for_pc();
     void populate_controls();
     void populate_for_cabinet();
+    void toggle_visibility(bool on);
     void tick_ui();
     void draw_menu_options();
     void draw_text(std::string);
+    void close_menu(void);
     void tick_menu();
     bool select_pressed();
     void set_menu(std::vector<std::string>*);

--- a/src/main/frontend/menulabels.hpp
+++ b/src/main/frontend/menulabels.hpp
@@ -113,3 +113,6 @@ const static char* ANALOG_LABELS[3] = { "OFF", "ON", "ON WHEEL ONLY" };
 const static char* VIDEO_LABELS[3] = { "OFF", "ON", "STRETCH" };
 const static char* RUMBLE_LABELS[5] = { "OFF", "LOW", "MED", "HIGH", "FULL" };
 const static char* CAB_LABELS[3] = { "MOVING", "UPRIGHT", "MINI" };
+
+// Special menu to double-check before quitting
+const static char* ENTRY_RETURN_TO_GAME = "RETURN TO GAME";

--- a/src/main/main.hpp
+++ b/src/main/main.hpp
@@ -21,6 +21,7 @@ namespace cannonball
 
     // Engine Master State
     extern int state;
+    extern int last_nonmenu_state;
     
     enum
     {
@@ -29,6 +30,7 @@ namespace cannonball
         STATE_MENU,
         STATE_INIT_GAME,
         STATE_GAME,
+        STATE_CONFIRM_QUIT,
         STATE_QUIT
     };
 }

--- a/src/main/sdl2/input.cpp
+++ b/src/main/sdl2/input.cpp
@@ -189,6 +189,10 @@ void Input::handle_key(const int key, const bool is_pressed)
         case SDLK_F5:
             keys[MENU] = is_pressed;
             break;
+
+        case SDLK_ESCAPE:
+            keys[ESCAPE] = is_pressed;
+            break;
     }
 }
 

--- a/src/main/sdl2/input.hpp
+++ b/src/main/sdl2/input.hpp
@@ -34,10 +34,12 @@ public:
         STEP  = 12,
         TIMER = 13,
         MENU = 14,     
+        ESCAPE = 15,
+        NUM_SPECIAL_KEYS
     };
 
-    bool keys[15];
-    bool keys_old[15];
+    bool keys[NUM_SPECIAL_KEYS];
+    bool keys_old[NUM_SPECIAL_KEYS];
 
     enum limits
     {

--- a/src/main/video.cpp
+++ b/src/main/video.cpp
@@ -153,13 +153,13 @@ void Video::set_shadow_intensity(float f)
     renderer->set_shadow_intensity(f);
 }
 
-void Video::prepare_frame()
+void Video::prepare_frame(bool force_clear)
 {
     // Renderer Specific Frame Setup
     if (!renderer->start_frame())
         return;
 
-    if (!enabled)
+    if (!enabled || force_clear)
     {
         // Fill with black pixels
         for (int i = 0; i < config.s16_width * config.s16_height; i++)

--- a/src/main/video.hpp
+++ b/src/main/video.hpp
@@ -44,7 +44,7 @@ public:
     void disable();
     int set_video_mode(video_settings_t* settings);
     void set_shadow_intensity(float);
-    void prepare_frame();
+    void prepare_frame(bool force_clear = false);
     void render_frame();
     bool supports_window();
     bool supports_vsync();


### PR DESCRIPTION
I noticed that entering initials after a race felt a little fiddly with keyboard controls because OHIScore::do_input() is looking for a fairly large steering signal to shift the selected letter.  This patch moderates the steering sensitivity for that page only when the input source is not an analog joystick or gamepad.  There are no changes to behavior using a joystick or gamepad, and no changes to actual gameplay regardless of input method.