### PR TITLE
Added rudimentary platform detection to CMakeLists.txt

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -300,9 +300,14 @@ target_link_libraries(cannonball
 # Copy useful files to build destination
 # -----------------------------------------------------------------------------
 
-configure_file(../res/config.xml ./config.xml 
-    COPYONLY
-)
+if (NOT EXISTS "./config.xml")
+    configure_file(../res/config.xml ./config.xml 
+        COPYONLY
+    )
+else ()
+    message(WARNING "Preserving existing config.xml. If it's from an older engine version, you may want "
+                    "to replace it with the default version from res/.")
+endif ()
 
 configure_file(../res/tilemap.bin ./res/tilemap.bin
     COPYONLY 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,7 +13,35 @@ project (cannonball)
 # -----------------------------------------------------------------------------
 
 # CMake default file (override with -DTARGET=file)
-set(DCMAKE win64-opengl.cmake)
+if(NOT DEFINED TARGET)
+	# Check to see whether the toolchain is set up for a particular CPU target
+	if (DEFINED CMAKE_CXX_FLAGS AND CMAKE_CXX_FLAGS MATCHES ".*-march=.*")
+        set(TARGET_ARCH_REGEX "^.*-march[= ]([^ ]+).*$")
+        string(REGEX MATCH "${TARGET_ARCH_REGEX}" TARGET_ARCH_MATCH ${CMAKE_CXX_FLAGS})
+        if (TARGET_ARCH_MATCH)
+           string(REGEX REPLACE "${TARGET_ARCH_REGEX}" "\\1" TARGET_ARCH ${CMAKE_CXX_FLAGS})
+        else()
+			# Could not extract target architecture, assume same as host
+            set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+		endif()
+	else()
+		# Assume we are not cross-compiling
+        set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    endif()
+	message("Detected target architecture as ${TARGET_ARCH}")
+
+	if (TARGET_ARCH MATCHES "[Aa]?[Aa][Rr][Mm].*")
+		message("Detected ARM target, setting up for Rasberry Pi OpenGL ES build; use -DTARGET= to change")
+        set(DCMAKE pi4-opengles.cmake)
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+		message("Automatically setting up for a Windows build; use -DTARGET= to change")
+        set(DCMAKE win64-opengl.cmake)
+    else()
+		message("Automatically setting up for a Linux/Unix build; use -DTARGET= to change")
+		set(OpenGL_GL_PREFERENCE GLVND)
+        set(DCMAKE linux.cmake)
+    endif()
+endif()
 
 # Source location
 set(main_cpp_base ../src/main)


### PR DESCRIPTION
Changed this so non-Windows users don't need to manually edit CMakeLists or pass a -DTARGET= every time.  The RPi detection (just looking for a GCC-style -march=arm in CMAKE_CXX_FLAGS) is pretty rudimentary (not necessarily what users on other ARM platforms are looking for, and won't detect cross-compilation on non-GCC toolchains), but at least it (a) provides a warning message to show the inferred platform, and (b) doesn't create any more inconvenience than the old "assume Windows 64" behavior did.