### PR TITLE
Changed ESC key to trigger confirmation menu instead of immediately exiting the game

### DIFF
--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -23,6 +23,9 @@ public:
     void populate();
     void init(bool init_main_menu = true);
     void tick();
+    void set_next_menu(int which);
+
+    enum { MAIN_MENU, CONFIRM_QUIT };
 
 private:
     CabDiag* cabdiag;
@@ -94,15 +97,18 @@ private:
     std::vector<std::string> menu_s_tests;          // smartypi specific
     std::vector<std::string> menu_s_dips;           // smartypi specific
     std::vector<std::string> menu_s_enhance;        // smartypi specific
+    std::vector<std::string> menu_confirm_quit;
 
     std::vector<std::string> text_redefine;
     
     void populate_for_pc();
     void populate_controls();
     void populate_for_cabinet();
+    void toggle_visibility(bool on);
     void tick_ui();
     void draw_menu_options();
     void draw_text(std::string);
+    void close_menu(void);
     void tick_menu();
     bool select_pressed();
     void set_menu(std::vector<std::string>*);

--- a/src/main/frontend/menulabels.hpp
+++ b/src/main/frontend/menulabels.hpp
@@ -113,3 +113,6 @@ const static char* ANALOG_LABELS[3] = { "OFF", "ON", "ON WHEEL ONLY" };
 const static char* VIDEO_LABELS[3] = { "OFF", "ON", "STRETCH" };
 const static char* RUMBLE_LABELS[5] = { "OFF", "LOW", "MED", "HIGH", "FULL" };
 const static char* CAB_LABELS[3] = { "MOVING", "UPRIGHT", "MINI" };
+
+// Special menu to double-check before quitting
+const static char* ENTRY_RETURN_TO_GAME = "RETURN TO GAME";

--- a/src/main/main.hpp
+++ b/src/main/main.hpp
@@ -21,6 +21,7 @@ namespace cannonball
 
     // Engine Master State
     extern int state;
+    extern int last_nonmenu_state;
     
     enum
     {
@@ -29,6 +30,7 @@ namespace cannonball
         STATE_MENU,
         STATE_INIT_GAME,
         STATE_GAME,
+        STATE_CONFIRM_QUIT,
         STATE_QUIT
     };
 }

--- a/src/main/sdl2/input.cpp
+++ b/src/main/sdl2/input.cpp
@@ -189,6 +189,10 @@ void Input::handle_key(const int key, const bool is_pressed)
         case SDLK_F5:
             keys[MENU] = is_pressed;
             break;
+
+        case SDLK_ESCAPE:
+            keys[ESCAPE] = is_pressed;
+            break;
     }
 }
 

--- a/src/main/sdl2/input.hpp
+++ b/src/main/sdl2/input.hpp
@@ -34,10 +34,12 @@ public:
         STEP  = 12,
         TIMER = 13,
         MENU = 14,     
+        ESCAPE = 15,
+        NUM_SPECIAL_KEYS
     };
 
-    bool keys[15];
-    bool keys_old[15];
+    bool keys[NUM_SPECIAL_KEYS];
+    bool keys_old[NUM_SPECIAL_KEYS];
 
     enum limits
     {

--- a/src/main/video.cpp
+++ b/src/main/video.cpp
@@ -153,13 +153,13 @@ void Video::set_shadow_intensity(float f)
     renderer->set_shadow_intensity(f);
 }
 
-void Video::prepare_frame()
+void Video::prepare_frame(bool force_clear)
 {
     // Renderer Specific Frame Setup
     if (!renderer->start_frame())
         return;
 
-    if (!enabled)
+    if (!enabled || force_clear)
     {
         // Fill with black pixels
         for (int i = 0; i < config.s16_width * config.s16_height; i++)

--- a/src/main/video.hpp
+++ b/src/main/video.hpp
@@ -44,7 +44,7 @@ public:
     void disable();
     int set_video_mode(video_settings_t* settings);
     void set_shadow_intensity(float);
-    void prepare_frame();
+    void prepare_frame(bool force_clear = false);
     void render_frame();
     bool supports_window();
     bool supports_vsync();


### PR DESCRIPTION
Prevent accidental exits by triggering a "Resume game" / "Exit" menu instead of immediately quitting.  This also works as an alternate pause menu.

Additionally, pressing ESC while in a menu (this new one, or main menu system) now exits the menu interface without saving your latest changes.  This can be used to interrupt a set of input redefinitions, or just to make it easier to back out of the menu interface.