### PR TITLE
Make it easier to enter initials with keyboard controls on the high-score page

### DIFF
--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -393,8 +393,8 @@ int8_t OHiScore::read_controls()
         slow_threshold = 0x10;
     } else {
 	// Don't demand as much of a steering input to change letters when using keyboard
-        fast_threshold = 0x10;
-        slow_threshold = 0x04;
+        fast_threshold = 0x0A;
+        slow_threshold = 0x01;
     }
 
     // Determine when accelerator has been pressed then depressed

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -386,6 +386,17 @@ void OHiScore::do_input(uint32_t adr)
 // Source: 0xD4DA
 int8_t OHiScore::read_controls()
 {
+    int fast_threshold, slow_threshold;
+
+    if (input.analog || input.gamepad) {
+        fast_threshold = 0x30;
+        slow_threshold = 0x10;
+    } else {
+	// Don't demand as much of a steering input to change letters when using keyboard
+        fast_threshold = 0x10;
+        slow_threshold = 0x04;
+    }
+
     // Determine when accelerator has been pressed then depressed
     if (oinputs.input_acc < 0x30)
     {
@@ -404,7 +415,7 @@ int8_t OHiScore::read_controls()
 
     // Check Steering Wheel
     int8_t movement = 1; // default to right
-    int16_t steering = (oinputs.input_steering & 0xFF) - 0x80;
+    int16_t steering = (oinputs.input_steering & 0xFF) - OInputs::STEERING_CENTRE;
     if (steering < 0)
     {
         steering = -steering;
@@ -413,9 +424,9 @@ int8_t OHiScore::read_controls()
 
     // Set increment to potentially advance to next letter.
     // This depends on how far the steering wheel is turned.
-    if (steering >= 0x30)
+    if (steering >= fast_threshold)
         steer += 5;
-    else if (steering >= 0x10)
+    else if (steering >= slow_threshold)
         steer += 1;
 
     if (steer >= 0x14)

--- a/src/main/engine/oinputs.hpp
+++ b/src/main/engine/oinputs.hpp
@@ -51,6 +51,9 @@ public:
     bool is_analog_r();
     bool is_analog_select();
 
+    // Steering position is a one-byte value, center of range == neutral
+    const static uint8_t STEERING_CENTRE = 0x80;
+
 private:
     // ------------------------------------------------------------------------
     // Variables for port
@@ -77,7 +80,6 @@ private:
 
     const static uint8_t STEERING_MIN = 0x48;
     const static uint8_t STEERING_MAX = 0xB8;
-    const static uint8_t STEERING_CENTRE = 0x80;
     
     // Current steering value
     int16_t steering_old;


### PR DESCRIPTION
Reopens the old #150 just changing the source branch name, so that I can pull newer changes into the `master` of my own fork, but leave the PRs separated for easier review.

Original text: I noticed that entering initials after a race felt a little fiddly with keyboard controls because OHIScore::do_input() is looking for a fairly large steering signal to shift the selected letter. This patch moderates the steering sensitivity for that page only when the input source is not an analog joystick or gamepad. There are no changes to behavior using a joystick or gamepad, and no changes to actual gameplay regardless of input method.