### PR TITLE
Add explicit macos support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Everything should go into a win64.cmake equivalent.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.3.2) # Might compile lower, but untested
+cmake_minimum_required (VERSION 3.5...3.31)
 project (cannonball)
 
 # -----------------------------------------------------------------------------
@@ -13,7 +13,14 @@ project (cannonball)
 # -----------------------------------------------------------------------------
 
 # CMake default file (override with -DTARGET=file)
-set(DCMAKE win64-opengl.cmake)
+# Auto-detect platform if TARGET not specified
+if(APPLE)
+    set(DCMAKE macos.cmake)
+elseif(UNIX)
+    set(DCMAKE linux.cmake)
+else()
+    set(DCMAKE win64-opengl.cmake)
+endif()
 
 # Source location
 set(main_cpp_base ../src/main)
@@ -255,7 +262,7 @@ message("SDL2 Libraries: ${SDL2_LIBRARIES}")
 # Include
 include_directories(
     ${main_cpp_base}
-    ${BOOST_INCLUDEDIR}
+    ${Boost_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIRS}
 )
 

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -1,0 +1,31 @@
+# -----------------------------------------------------------------------------
+# CannonBall macOS Setup
+#
+# Works on both Intel and Apple Silicon Macs.
+# Uses SDL2's accelerated renderer (which uses Metal on macOS).
+#
+# Dependencies (install via Homebrew):
+#   brew install sdl2 boost cmake
+#
+# Build:
+#   cd cmake
+#   mkdir build && cd build
+#   cmake -DTARGET=macos.cmake ..
+#   make
+# -----------------------------------------------------------------------------
+
+# Use SDL2 software renderer (which uses Metal acceleration on macOS)
+# Do NOT set OPENGL or OPENGLES - this selects rendersurface.cpp
+
+# Let CMake find SDL2 and Boost via Homebrew paths
+# Homebrew installs to /opt/homebrew on Apple Silicon, /usr/local on Intel
+# find_package() handles both automatically
+
+# Platform Specific Libraries
+# SDL2 is linked via find_package() in main CMakeLists.txt
+set(platform_link_libs
+)
+
+# Platform Specific Link Directories
+set(platform_link_dirs
+)


### PR DESCRIPTION
  ## Summary
  - Add native macOS build support for both Intel and Apple Silicon Macs
  - Fix CMake compatibility issues with modern CMake versions
  - Fix Boost include path detection

  ## Changes

  ### New: `cmake/macos.cmake`
  macOS build configuration that uses SDL2's software renderer. Despite the name, SDL2 uses Metal as its rendering backend on macOS, providing GPU acceleration without relying on deprecated OpenGL.

  ### Updated: `cmake/CMakeLists.txt`
  - Update `cmake_minimum_required` to `3.5...3.31` (fixes compatibility with modern CMake)
  - Add platform auto-detection: defaults to `macos.cmake` on macOS, `linux.cmake` on Linux
  - Fix `Boost_INCLUDE_DIRS` variable name (was incorrectly using the hint variable `BOOST_INCLUDEDIR`)
  
  
   ## Build instructions
  ```bash
  brew install sdl2 boost cmake
  cd cmake
  mkdir build && cd build
  cmake ..
  make